### PR TITLE
Extract out DownloadManager from download service.

### DIFF
--- a/lib/services/download/download_manager.dart
+++ b/lib/services/download/download_manager.dart
@@ -1,0 +1,89 @@
+// Copyright 2020-2021 Ben Hills. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:ui';
+
+import 'package:anytime/entities/downloadable.dart';
+import 'package:flutter_downloader/flutter_downloader.dart';
+
+class DownloadProgress {
+  final String id;
+  final int percentage;
+  final DownloadState status;
+
+  DownloadProgress(this.id, this.percentage, this.status);
+}
+
+abstract class DownloadManager {
+  Future<String> enqueTask(String url, String downloadPath, String fileName);
+  Stream<DownloadProgress> get downloadProgress;
+  void dispose();
+}
+
+class FlutterDownloaderManager implements DownloadManager {
+  final ReceivePort _port = ReceivePort();
+  final downloadController = StreamController<DownloadProgress>();
+
+  @override
+  Stream<DownloadProgress> get downloadProgress => downloadController.stream;
+
+  FlutterDownloaderManager() {
+    _init();
+  }
+
+  Future _init() async {
+    await FlutterDownloader.initialize();
+
+    IsolateNameServer.registerPortWithName(_port.sendPort, 'downloader_send_port');
+    _port.listen((dynamic data) {
+      final id = data[0] as String;
+      final status = data[1] as DownloadTaskStatus;
+      final progress = data[2] as int;
+
+      var state = DownloadState.none;
+
+      if (status == DownloadTaskStatus.enqueued) {
+        state = DownloadState.queued;
+      } else if (status == DownloadTaskStatus.canceled) {
+        state = DownloadState.cancelled;
+      } else if (status == DownloadTaskStatus.complete) {
+        state = DownloadState.downloaded;
+      } else if (status == DownloadTaskStatus.running) {
+        state = DownloadState.downloading;
+      } else if (status == DownloadTaskStatus.failed) {
+        state = DownloadState.failed;
+      } else if (status == DownloadTaskStatus.paused) {
+        state = DownloadState.paused;
+      }
+
+      downloadController.add(DownloadProgress(id, progress, state));
+    });
+    FlutterDownloader.registerCallback(downloadCallback);
+  }
+
+  @override
+  Future<String> enqueTask(String url, String downloadPath, String fileName) async {
+    return await FlutterDownloader.enqueue(
+      url: url,
+      savedDir: downloadPath,
+      fileName: fileName,
+      showNotification: true,
+      openFileFromNotification: false,
+    );
+  }
+
+  @override
+  void dispose() {
+    IsolateNameServer.removePortNameMapping('downloader_send_port');
+    downloadController.close();
+  }
+
+  static void downloadCallback(String id, DownloadTaskStatus status, int progress) {
+    final send = IsolateNameServer.lookupPortByName('downloader_send_port');
+
+    send.send([id, status, progress]);
+  }
+}

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -16,6 +16,7 @@ import 'package:anytime/repository/repository.dart';
 import 'package:anytime/repository/sembast/sembast_repository.dart';
 import 'package:anytime/services/audio/audio_player_service.dart';
 import 'package:anytime/services/audio/mobile_audio_service.dart';
+import 'package:anytime/services/download/download_manager.dart';
 import 'package:anytime/services/download/download_service.dart';
 import 'package:anytime/services/download/mobile_download_service.dart';
 import 'package:anytime/services/podcast/mobile_podcast_service.dart';
@@ -59,7 +60,7 @@ class AnytimePodcastApp extends StatefulWidget {
   AnytimePodcastApp(this.mobileSettingsService)
       : repository = SembastRepository(),
         podcastApi = MobilePodcastApi() {
-    downloadService = MobileDownloadService(repository: repository);
+    downloadService = MobileDownloadService(repository: repository, downloadManager: FlutterDownloaderManager());
     podcastService = MobilePodcastService(api: podcastApi, repository: repository, settingsService: mobileSettingsService);
     audioPlayerService = MobileAudioPlayerService(repository: repository);
     settingsBloc = SettingsBloc(mobileSettingsService);


### PR DESCRIPTION
This PR separates (extract out) a small "DownloadManager" interface from the currently MobileDownloadService.
This change allows embedding anytime inside other apps and use the same FlutterDownloader plugin, overcoming its singleton requirement.
In addition it enables using a different implementation of download service and tasks management.
This PR should not cause in any behavioural changes.