### PR TITLE
Allow controlling top bar visibility

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -177,8 +177,9 @@ class _AnytimePodcastAppState extends State<AnytimePodcastApp> {
 
 class AnytimeHomePage extends StatefulWidget {
   final String title;
+  final bool topBarVisible;
 
-  AnytimeHomePage({this.title});
+  AnytimeHomePage({this.title, this.topBarVisible = true});
 
   @override
   _AnytimeHomePageState createState() => _AnytimeHomePageState();
@@ -237,47 +238,50 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
             child: CustomScrollView(
               // physics: NeverScrollableScrollPhysics(),
               slivers: <Widget>[
-                SliverAppBar(
-                  title: TitleWidget(),
-                  brightness: brightness,
-                  backgroundColor: backgroundColour,
-                  floating: false,
-                  pinned: true,
-                  snap: false,
-                  actions: <Widget>[
-                    IconButton(
-                      tooltip: L.of(context).search_button_label,
-                      icon: Icon(Icons.search),
-                      onPressed: () async {
-                        await Navigator.push(
-                          context,
-                          SlideRightRoute(widget: Search()),
-                        );
-                      },
-                    ),
-                    PopupMenuButton<String>(
-                      color: Theme.of(context).dialogBackgroundColor,
-                      onSelected: _menuSelect,
-                      icon: Icon(
-                        Icons.more_vert,
-                        // color: Theme.of(context).buttonColor,
+                SliverVisibility(
+                  visible: widget.topBarVisible,
+                  sliver: SliverAppBar(
+                    title: TitleWidget(),
+                    brightness: brightness,
+                    backgroundColor: backgroundColour,
+                    floating: false,
+                    pinned: true,
+                    snap: false,
+                    actions: <Widget>[
+                      IconButton(
+                        tooltip: L.of(context).search_button_label,
+                        icon: Icon(Icons.search),
+                        onPressed: () async {
+                          await Navigator.push(
+                            context,
+                            SlideRightRoute(widget: Search()),
+                          );
+                        },
                       ),
-                      itemBuilder: (BuildContext context) {
-                        return <PopupMenuEntry<String>>[
-                          PopupMenuItem<String>(
-                            textStyle: Theme.of(context).textTheme.subtitle1,
-                            value: 'settings',
-                            child: Text('Settings'), //TODO: FIX
-                          ),
-                          PopupMenuItem<String>(
-                            textStyle: Theme.of(context).textTheme.subtitle1,
-                            value: 'about',
-                            child: Text(L.of(context).about_label),
-                          ),
-                        ];
-                      },
-                    ),
-                  ],
+                      PopupMenuButton<String>(
+                        color: Theme.of(context).dialogBackgroundColor,
+                        onSelected: _menuSelect,
+                        icon: Icon(
+                          Icons.more_vert,
+                          // color: Theme.of(context).buttonColor,
+                        ),
+                        itemBuilder: (BuildContext context) {
+                          return <PopupMenuEntry<String>>[
+                            PopupMenuItem<String>(
+                              textStyle: Theme.of(context).textTheme.subtitle1,
+                              value: 'settings',
+                              child: Text('Settings'), //TODO: FIX
+                            ),
+                            PopupMenuItem<String>(
+                              textStyle: Theme.of(context).textTheme.subtitle1,
+                              value: 'about',
+                              child: Text(L.of(context).about_label),
+                            ),
+                          ];
+                        },
+                      ),
+                    ],
+                  ),
                 ),
                 StreamBuilder<int>(
                     stream: pager.currentPage,


### PR DESCRIPTION
This PR adds an additional parameter to the `AnytimeHomePage` which allows to  control whether the top bar is visible or hidden.
This enables embedding the main view inside another app that uses different top bar.
The default behaviour remains as it is today (visible: true).