### PR TITLE
Implement settings to automatically maximize player.

### DIFF
--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -16,6 +16,7 @@ class SettingsBloc extends Bloc {
   final BehaviorSubject<bool> _markDeletedAsPlayed = BehaviorSubject<bool>();
   final BehaviorSubject<bool> _storeDownloadonSDCard = BehaviorSubject<bool>();
   final BehaviorSubject<double> _playbackSpeed = BehaviorSubject<double>();
+  final BehaviorSubject<bool> _autoOpenNowPlaying = BehaviorSubject<bool>();
 
   SettingsBloc(this._settingsService) {
     _init();
@@ -27,14 +28,15 @@ class SettingsBloc extends Bloc {
     var markDeletedEpisodesAsPlayed = _settingsService.markDeletedEpisodesAsPlayed;
     var storeDownloadsSDCard = _settingsService.storeDownloadsSDCard;
     var playbackSpeed = _settingsService.playbackSpeed;
+    var autoOpenNowPlaying = _settingsService.autoOpenNowPlaying;
     var themeName = themeDarkMode ? 'dark' : 'light';
 
     var s = AppSettings(
-      theme: themeDarkMode ? 'dark' : 'light',
-      markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
-      storeDownloadsSDCard: storeDownloadsSDCard,
-      playbackSpeed: playbackSpeed,
-    );
+        theme: themeDarkMode ? 'dark' : 'light',
+        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+        storeDownloadsSDCard: storeDownloadsSDCard,
+        playbackSpeed: playbackSpeed,
+        autoOpenNowPlaying: autoOpenNowPlaying);
 
     _settings.add(s);
 
@@ -42,11 +44,11 @@ class SettingsBloc extends Bloc {
       themeName = darkMode ? 'dark' : 'light';
 
       s = AppSettings(
-        theme: themeName,
-        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
-        storeDownloadsSDCard: storeDownloadsSDCard,
-        playbackSpeed: playbackSpeed,
-      );
+          theme: themeName,
+          markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+          storeDownloadsSDCard: storeDownloadsSDCard,
+          playbackSpeed: playbackSpeed,
+          autoOpenNowPlaying: autoOpenNowPlaying);
 
       _settings.add(s);
 
@@ -57,11 +59,11 @@ class SettingsBloc extends Bloc {
       markDeletedEpisodesAsPlayed = mark;
 
       s = AppSettings(
-        theme: themeName,
-        markDeletedEpisodesAsPlayed: mark,
-        storeDownloadsSDCard: storeDownloadsSDCard,
-        playbackSpeed: playbackSpeed,
-      );
+          theme: themeName,
+          markDeletedEpisodesAsPlayed: mark,
+          storeDownloadsSDCard: storeDownloadsSDCard,
+          playbackSpeed: playbackSpeed,
+          autoOpenNowPlaying: autoOpenNowPlaying);
 
       _settings.add(s);
 
@@ -72,11 +74,11 @@ class SettingsBloc extends Bloc {
       storeDownloadsSDCard = sdcard;
 
       s = AppSettings(
-        theme: themeName,
-        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
-        storeDownloadsSDCard: storeDownloadsSDCard,
-        playbackSpeed: playbackSpeed,
-      );
+          theme: themeName,
+          markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+          storeDownloadsSDCard: storeDownloadsSDCard,
+          playbackSpeed: playbackSpeed,
+          autoOpenNowPlaying: autoOpenNowPlaying);
 
       _settings.add(s);
 
@@ -85,17 +87,32 @@ class SettingsBloc extends Bloc {
 
     _playbackSpeed.listen((double speed) {
       s = AppSettings(
-        theme: themeName,
-        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
-        storeDownloadsSDCard: storeDownloadsSDCard,
-        playbackSpeed: speed,
-      );
+          theme: themeName,
+          markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+          storeDownloadsSDCard: storeDownloadsSDCard,
+          playbackSpeed: speed,
+          autoOpenNowPlaying: autoOpenNowPlaying);
 
       _settings.add(s);
 
       print('Setting speed to $speed');
 
       _settingsService.playbackSpeed = speed;
+    });
+
+    _autoOpenNowPlaying.listen((bool autoOpen) {
+      autoOpenNowPlaying = autoOpen;
+
+      s = AppSettings(
+          theme: themeName,
+          markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+          storeDownloadsSDCard: storeDownloadsSDCard,
+          playbackSpeed: playbackSpeed,
+          autoOpenNowPlaying: autoOpen);
+
+      _settings.add(s);
+
+      _settingsService.autoOpenNowPlaying = autoOpen;
     });
   }
 
@@ -108,6 +125,8 @@ class SettingsBloc extends Bloc {
   void Function(bool) get markDeletedAsPlayed => _markDeletedAsPlayed.add;
 
   void Function(double) get setPlaybackSpeed => _playbackSpeed.add;
+
+  void Function(bool) get setAutoOpenNowPlaying => _autoOpenNowPlaying.add;
 
   @override
   void dispose() {

--- a/lib/entities/app_settings.dart
+++ b/lib/entities/app_settings.dart
@@ -9,17 +9,20 @@ class AppSettings {
   final bool markDeletedEpisodesAsPlayed;
   final bool storeDownloadsSDCard;
   final double playbackSpeed;
+  final bool autoOpenNowPlaying;
 
   AppSettings({
     @required this.theme,
     @required this.markDeletedEpisodesAsPlayed,
     @required this.storeDownloadsSDCard,
     @required this.playbackSpeed,
+    @required this.autoOpenNowPlaying,
   });
 
   AppSettings.sensibleDefaults()
       : theme = 'dark',
         markDeletedEpisodesAsPlayed = false,
         storeDownloadsSDCard = false,
-        playbackSpeed = 1.0;
+        playbackSpeed = 1.0,
+        autoOpenNowPlaying = false;
 }

--- a/lib/l10n/L.dart
+++ b/lib/l10n/L.dart
@@ -470,6 +470,15 @@ class L {
       locale: localeName,
     );
   }
+
+  String get settings_auto_open_now_playing {
+    return Intl.message(
+      'Full screen player mode',
+      name: 'settings_auto_open_now_playing',
+      desc: 'Displayed when user switches to use full screen player automatically',
+      locale: localeName,
+    );
+  }
 }
 
 class LocalisationsDelegate extends LocalizationsDelegate<L> {

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -287,5 +287,11 @@
     "description": "Set show notes icon label",
     "type": "text",
     "placeholders": {}
+  },
+  "settings_auto_open_now_playing": "Full screen player mode",
+  "@settings_auto_open_now_playing": {
+    "description": "Displayed when user switches to use full screen player automatically",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -287,5 +287,11 @@
     "description": "Set show notes icon label",
     "type": "text",
     "placeholders": {}
+  },
+  "settings_auto_open_now_playing": "Full screen player mode",
+  "@settings_auto_open_now_playing": {
+    "description": "Displayed when user switches to use full screen player automatically",
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2021-01-25T13:45:36.008606",
+  "@@last_modified": "2021-02-02T20:56:59.328637",
   "app_title": "Anytime Podcast Player",
   "@app_title": {
     "description": "Full title for the application",
@@ -291,6 +291,12 @@
   "show_notes_label": "Show notes",
   "@show_notes_label": {
     "description": "Set show notes icon label",
+    "type": "text",
+    "placeholders": {}
+  },
+  "settings_auto_open_now_playing": "Full screen player mode",
+  "@settings_auto_open_now_playing": {
+    "description": "Displayed when user switches to use full screen player automatically",
     "type": "text",
     "placeholders": {}
   }

--- a/lib/l10n/messages_de.dart
+++ b/lib/l10n/messages_de.dart
@@ -54,6 +54,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "search_back_button_label" : MessageLookupByLibrary.simpleMessage("Zurück"),
     "search_button_label" : MessageLookupByLibrary.simpleMessage("Suche"),
     "search_for_podcasts_hint" : MessageLookupByLibrary.simpleMessage("Suche nach Podcasts"),
+    "settings_auto_open_now_playing" : MessageLookupByLibrary.simpleMessage("Full screen player mode"),
     "settings_download_sd_card_label" : MessageLookupByLibrary.simpleMessage("Episoden auf SD-Karte herunterladen"),
     "settings_download_switch_card" : MessageLookupByLibrary.simpleMessage("Neue Downloads werden auf der SD-Karte gespeichert. Bestehende Downloads bleiben im internen Speicher."),
     "settings_download_switch_internal" : MessageLookupByLibrary.simpleMessage("Neue Downloads werden im internen Speicher gespeichert. Bestehende Downloads verbleiben auf der SD-Karte."),

--- a/lib/l10n/messages_en.dart
+++ b/lib/l10n/messages_en.dart
@@ -54,6 +54,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "search_back_button_label" : MessageLookupByLibrary.simpleMessage("Back"),
     "search_button_label" : MessageLookupByLibrary.simpleMessage("Search"),
     "search_for_podcasts_hint" : MessageLookupByLibrary.simpleMessage("Search for podcasts"),
+    "settings_auto_open_now_playing" : MessageLookupByLibrary.simpleMessage("Full screen player mode"),
     "settings_download_sd_card_label" : MessageLookupByLibrary.simpleMessage("Download episodes to SD card"),
     "settings_download_switch_card" : MessageLookupByLibrary.simpleMessage("New downloads will be saved to the SD card. Existing downloads will remain on internal storage."),
     "settings_download_switch_internal" : MessageLookupByLibrary.simpleMessage("New downloads will be saved to internal storage. Existing downloads will remain on the SD card."),

--- a/lib/l10n/messages_messages.dart
+++ b/lib/l10n/messages_messages.dart
@@ -55,6 +55,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "search_back_button_label" : MessageLookupByLibrary.simpleMessage("Back"),
     "search_button_label" : MessageLookupByLibrary.simpleMessage("Search"),
     "search_for_podcasts_hint" : MessageLookupByLibrary.simpleMessage("Search for podcasts"),
+    "settings_auto_open_now_playing" : MessageLookupByLibrary.simpleMessage("Full screen player mode"),
     "settings_download_sd_card_label" : MessageLookupByLibrary.simpleMessage("Download episodes to SD card"),
     "settings_download_switch_card" : MessageLookupByLibrary.simpleMessage("New downloads will be saved to the SD card. Existing downloads will remain on internal storage."),
     "settings_download_switch_internal" : MessageLookupByLibrary.simpleMessage("New downloads will be saved to internal storage. Existing downloads will remain on the SD card."),

--- a/lib/services/settings/mobile_settings_service.dart
+++ b/lib/services/settings/mobile_settings_service.dart
@@ -63,5 +63,17 @@ class MobileSettingsService extends SettingsService {
   }
 
   @override
+  set autoOpenNowPlaying(bool autoOpenNowPlaying) {
+    _sharedPreferences
+        .setBool('autoopennowplaying', autoOpenNowPlaying)
+        .then((value) => print('Saved autoOpenNowPlaying of $autoOpenNowPlaying'));
+  }
+
+  @override
+  bool get autoOpenNowPlaying {
+    return _sharedPreferences.getBool('autoopennowplaying') ?? true;
+  }
+
+  @override
   AppSettings settings;
 }

--- a/lib/services/settings/settings_service.dart
+++ b/lib/services/settings/settings_service.dart
@@ -20,4 +20,8 @@ abstract class SettingsService {
   set playbackSpeed(double playbackSpeed);
 
   double get playbackSpeed;
+
+  set autoOpenNowPlaying(bool autoOpenNowPlaying);
+
+  bool get autoOpenNowPlaying;
 }

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -174,7 +174,7 @@ class _PlayButton extends StatelessWidget {
             child: const SpinKitRing(
               lineWidth: 2.0,
               color: Colors.blue,
-              size: 38.0,
+              size: 60,
             ),
           ));
     }

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -9,6 +9,7 @@ import 'package:anytime/l10n/L.dart';
 import 'package:anytime/services/audio/audio_player_service.dart';
 import 'package:anytime/ui/widgets/speed_selector_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:provider/provider.dart';
 
 /// Builds a transport control bar for rewind, play and fast-forward.
@@ -80,7 +81,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
       child: StreamBuilder<AudioState>(
           stream: audioBloc.playingState,
           builder: (context, snapshot) {
-            var playing = snapshot.data == AudioState.playing;
+            final audioState = snapshot.data;
 
             return Row(
               crossAxisAlignment: CrossAxisAlignment.center,
@@ -105,27 +106,11 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                     color: Theme.of(context).primaryColor,
                   ),
                 ),
-                Tooltip(
-                  message: playing ? L.of(context).pause_button_label : L.of(context).play_button_label,
-                  child: FlatButton(
-                    onPressed: () {
-                      if (playing) {
-                        _pause(audioBloc);
-                      } else {
-                        _play(audioBloc);
-                      }
-                    },
-                    shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
-                    padding: const EdgeInsets.all(8.0),
-                    child: AnimatedIcon(
-                      size: 60.0,
-                      icon: AnimatedIcons.play_pause,
-                      color: Colors.white,
-                      progress: _playPauseController,
-                    ),
-                  ),
-                ),
+                _PlayButton(
+                    audioState: audioState,
+                    onPlay: () => _play(audioBloc),
+                    onPause: () => _pause(audioBloc),
+                    playPauseController: _playPauseController),
                 IconButton(
                   onPressed: () {
                     _fastforward(audioBloc);
@@ -163,5 +148,57 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
 
   void _fastforward(AudioBloc audioBloc) {
     audioBloc.transitionState(TransitionState.fastforward);
+  }
+}
+
+class _PlayButton extends StatelessWidget {
+  final AudioState audioState;
+  final Function() onPlay;
+  final Function() onPause;
+  final AnimationController playPauseController;
+
+  const _PlayButton({Key key, this.audioState, this.onPlay, this.onPause, this.playPauseController}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final playing = audioState == AudioState.playing;
+    final bufferring = audioState == null || audioState == AudioState.buffering;
+
+    // in case we are bufferring show progress indicator.
+    if (bufferring) {
+      return Tooltip(
+          message: playing ? L.of(context).pause_button_label : L.of(context).play_button_label,
+          child: FlatButton(
+            onPressed: null,
+            padding: const EdgeInsets.all(8.0),
+            child: const SpinKitRing(
+              lineWidth: 2.0,
+              color: Colors.blue,
+              size: 38.0,
+            ),
+          ));
+    }
+
+    return Tooltip(
+      message: playing ? L.of(context).pause_button_label : L.of(context).play_button_label,
+      child: FlatButton(
+        onPressed: () {
+          if (playing) {
+            onPause();
+          } else {
+            onPlay();
+          }
+        },
+        shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
+        color: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
+        padding: const EdgeInsets.all(8.0),
+        child: AnimatedIcon(
+          size: 60.0,
+          icon: AnimatedIcons.play_pause,
+          color: Colors.white,
+          progress: playPauseController,
+        ),
+      ),
+    );
   }
 }

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -74,6 +74,13 @@ class _SettingsState extends State<Settings> {
                         : null,
                   ),
                 ),
+                ListTile(
+                  title: Text(L.of(context).settings_auto_open_now_playing),
+                  trailing: Switch.adaptive(
+                    value: snapshot.data.autoOpenNowPlaying,
+                    onChanged: (value) => setState(() => settingsBloc.setAutoOpenNowPlaying(value)),
+                  ),
+                ),
               ],
             ).toList());
           } else {


### PR DESCRIPTION
this PR introduces an `autoOpenNowPlaying` settings flag that allows the user to control the behaviour when the user plays an episode and showing automatically the "NowPlaying" view. This is useful for opening this view straight from search results instead of going back and press the mini player.
I didn't add the setting option to the UI, let me know if you would like that.