### PR TITLE
Open dialogs without using root navigator

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -405,6 +405,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
       case 'rss':
         await showPlatformDialog<void>(
           context: context,
+          useRootNavigator: false,
           builder: (_) => BasicDialogAlert(
             title: Text(L.of(context).add_rss_feed_option),
             content: TextField(

--- a/lib/ui/podcast/funding_menu.dart
+++ b/lib/ui/podcast/funding_menu.dart
@@ -153,6 +153,7 @@ class FundingLink {
     } else {
       result = await showPlatformDialog<bool>(
         context: context,
+        useRootNavigator: false,
         builder: (_) => BasicDialogAlert(
           title: Text(L.of(context).podcast_funding_dialog_header),
           content: Text(L.of(context).consent_message),

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -394,6 +394,7 @@ class SubscriptionButton extends StatelessWidget {
                       onPressed: () {
                         showPlatformDialog<void>(
                           context: context,
+                          useRootNavigator: false,
                           builder: (_) => BasicDialogAlert(
                             title: Text(L.of(context).unsubscribe_label),
                             content: Text(L.of(context).unsubscribe_message),

--- a/lib/ui/podcast/transport_controls.dart
+++ b/lib/ui/podcast/transport_controls.dart
@@ -234,6 +234,7 @@ class DownloadControl extends StatelessWidget {
 
     return showPlatformDialog<void>(
       context: context,
+      useRootNavigator: false,
       builder: (_) => BasicDialogAlert(
         title: Text(
           L.of(context).stop_download_title,

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -101,6 +101,7 @@ class _SettingsState extends State<Settings> {
 
                     var e = await showPlatformDialog<bool>(
                       androidBarrierDismissible: false,
+                      useRootNavigator: false,
                       context: context,
                       builder: (_) => WillPopScope(
                         onWillPop: () async => false,
@@ -131,6 +132,7 @@ class _SettingsState extends State<Settings> {
                 onTap: () async {
                   await showPlatformDialog<void>(
                     context: context,
+                    useRootNavigator: false,
                     builder: (_) => BasicDialogAlert(
                       content: OPMLExport(),
                     ),
@@ -168,6 +170,7 @@ class _SettingsState extends State<Settings> {
   void _showStorageDialog({@required bool enableExternalStorage}) {
     showPlatformDialog<void>(
       context: context,
+      useRootNavigator: false,
       builder: (_) => BasicDialogAlert(
         title: Text(L.of(context).settings_download_switch_label),
         content: Text(

--- a/lib/ui/widgets/episode_tile.dart
+++ b/lib/ui/widgets/episode_tile.dart
@@ -113,6 +113,7 @@ class EpisodeTile extends StatelessWidget {
                       ? () {
                           showPlatformDialog<void>(
                             context: context,
+                            useRootNavigator: false,
                             builder: (_) => BasicDialogAlert(
                               title: Text(
                                 L.of(context).delete_episode_title,

--- a/lib/ui/widgets/search_provider.dart
+++ b/lib/ui/widgets/search_provider.dart
@@ -7,6 +7,7 @@ import 'package:anytime/entities/app_settings.dart';
 import 'package:anytime/l10n/L.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:provider/provider.dart';
 
 class SearchProviderWidget extends StatefulWidget {
@@ -37,8 +38,9 @@ class _SearchProviderWidgetState extends State<SearchProviderWidget> {
                       title: Text(L.of(context).search_provider_label),
                       subtitle: Text(snapshot.data.searchProvider == 'itunes' ? 'iTunes' : 'PodcastIndex'),
                       onTap: () {
-                        showDialog<void>(
+                        showPlatformDialog<void>(
                           context: context,
+                          useRootNavigator: false,
                           builder: (BuildContext context) {
                             return AlertDialog(
                                 title: Text(L.of(context).search_provider_label),

--- a/lib/ui/widgets/speed_selector.dart
+++ b/lib/ui/widgets/speed_selector.dart
@@ -7,6 +7,7 @@ import 'package:anytime/entities/app_settings.dart';
 import 'package:anytime/l10n/L.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:provider/provider.dart';
 
 /// This widget allows the user to change the playback speed. Selecting the playback
@@ -63,8 +64,9 @@ class _SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
                   color: Theme.of(context).buttonColor,
                 ),
                 onPressed: () {
-                  showDialog<void>(
+                  showPlatformDialog<void>(
                     context: context,
+                    useRootNavigator: false,
                     builder: (BuildContext context) {
                       return AlertDialog(
                           title: Text(


### PR DESCRIPTION
Dialogs use root navigator by default. This causes issues when the plugin is opened through an app with it's own instance of Navigator. The dialogs should be pushed to the nearest Navigator from the context in this case.

For example:
 - The plugin is embedded into an app,
 - a dialog that belongs to the plugin is opened,
 - calling Navigator.pop(context) to close the dialog would pop the last item on app's Navigator instead of popping the dialog.