### PR TITLE
Theme Changes

### DIFF
--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -352,7 +352,7 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               GestureDetector(
                   child: Text(
                     'anytime@amugofjava.me.uk',
-                    style: TextStyle(decoration: TextDecoration.underline, color: Colors.orange),
+                    style: TextStyle(decoration: TextDecoration.underline, color: Theme.of(context).buttonColor),
                   ),
                   onTap: () {
                     _launchEmail();

--- a/lib/ui/anytime_podcast_app.dart
+++ b/lib/ui/anytime_podcast_app.dart
@@ -303,6 +303,8 @@ class _AnytimeHomePageState extends State<AnytimeHomePage> with WidgetsBindingOb
               type: BottomNavigationBarType.fixed,
               backgroundColor: Theme.of(context).bottomAppBarColor,
               selectedIconTheme: Theme.of(context).iconTheme,
+              selectedItemColor: Theme.of(context).iconTheme.color,
+              unselectedItemColor: Theme.of(context).disabledColor,
               currentIndex: snapshot.data,
               onTap: pager.changePage,
               items: <BottomNavigationBarItem>[

--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -79,7 +79,7 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                       elevation: 0.0,
                       leading: IconButton(
                         tooltip: L.of(context).minimise_player_window_button_label,
-                        icon: Icon(Icons.keyboard_arrow_down),
+                        icon: Icon(Icons.keyboard_arrow_down, color: Theme.of(context).buttonColor,),
                         onPressed: () => {
                           Navigator.pop(context),
                         },

--- a/lib/ui/podcast/player_position_controls.dart
+++ b/lib/ui/podcast/player_position_controls.dart
@@ -58,14 +58,14 @@ class PlayerPositionControls extends StatelessWidget {
                           value: p.toDouble(),
                           min: 0.0,
                           max: length.inSeconds.toDouble(),
-                          activeColor: Theme.of(context).primaryColor,
+                          activeColor: Theme.of(context).buttonColor,
                         )
                       : Slider(
                     onChanged: null,
                           value: 0,
                           min: 0.0,
                           max: 1.0,
-                          activeColor: Theme.of(context).primaryColor,
+                          activeColor: Theme.of(context).buttonColor,
                         ),
                 ),
                 Text(_formatDuration(Duration(seconds: timeRemaining))),

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -116,12 +116,12 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                       }
                     },
                     shape: CircleBorder(side: BorderSide(color: Theme.of(context).highlightColor, width: 0.0)),
-                    color: Theme.of(context).brightness == Brightness.light ? Colors.orange : Colors.grey[800],
+                    color: Theme.of(context).primaryColor,
                     padding: const EdgeInsets.all(8.0),
                     child: AnimatedIcon(
                       size: 60.0,
                       icon: AnimatedIcons.play_pause,
-                      color: Colors.white,
+                      color: Theme.of(context).scaffoldBackgroundColor,
                       progress: _playPauseController,
                     ),
                   ),

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -121,7 +121,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                     child: AnimatedIcon(
                       size: 60.0,
                       icon: AnimatedIcons.play_pause,
-                      color: Theme.of(context).scaffoldBackgroundColor,
+                      color: Theme.of(context).primaryColor == Colors.white ? Theme.of(context).scaffoldBackgroundColor : Colors.white,
                       progress: _playPauseController,
                     ),
                   ),

--- a/lib/ui/podcast/player_transport_controls.dart
+++ b/lib/ui/podcast/player_transport_controls.dart
@@ -102,7 +102,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                   icon: Icon(
                     Icons.replay_30,
                     size: 48.0,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).buttonColor,
                   ),
                 ),
                 Tooltip(
@@ -134,7 +134,7 @@ class _PlayerTransportControlsState extends State<PlayerTransportControls> with 
                   icon: Icon(
                     Icons.forward_30,
                     size: 48.0,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).buttonColor,
                   ),
                 ),
                 SpeedSelectorWidget(

--- a/lib/ui/themes.dart
+++ b/lib/ui/themes.dart
@@ -41,6 +41,7 @@ ThemeData _buildLightTheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     textTheme: Typography.material2018(platform: TargetPlatform.android).black,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).black,
     primaryIconTheme: IconThemeData(color: Colors.grey[800]),
     iconTheme: IconThemeData(color: Colors.orange),
     appBarTheme: base.appBarTheme.copyWith(
@@ -83,6 +84,7 @@ ThemeData _buildDarktheme() {
     errorColor: Color(0xffd32f2f),
     primaryTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     textTheme: Typography.material2018(platform: TargetPlatform.android).white,
+    accentTextTheme: Typography.material2018(platform: TargetPlatform.android).white,
     primaryIconTheme: IconThemeData(color: Colors.white),
     iconTheme: IconThemeData(color: Colors.white),
     dividerTheme: base.dividerTheme.copyWith(

--- a/lib/ui/widgets/mini_player_widget.dart
+++ b/lib/ui/widgets/mini_player_widget.dart
@@ -62,7 +62,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = Theme.of(context).accentTextTheme;
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
     return Dismissible(
@@ -93,8 +93,8 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
           decoration: BoxDecoration(
               color: Theme.of(context).bottomAppBarColor,
               border: Border(
-                top: Divider.createBorderSide(context, width: 1.0),
-                bottom: Divider.createBorderSide(context, width: 1.0),
+                top: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
+                bottom: Divider.createBorderSide(context, width: 1.0, color: Theme.of(context).dividerColor),
               )),
           child: StreamBuilder<Episode>(
               stream: audioBloc.nowPlaying,
@@ -170,7 +170,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).accentColor,
+                                color: Theme.of(context).iconTheme.color,
                                 progress: _playPauseController,
                               ),
                             );

--- a/lib/ui/widgets/play_pause_button_widget.dart
+++ b/lib/ui/widgets/play_pause_button_widget.dart
@@ -70,9 +70,9 @@ class PlayPauseBusyButton extends StatelessWidget {
                   color: Theme.of(context).buttonColor,
                 ),
               ),
-              const SpinKitRing(
+              SpinKitRing(
                 lineWidth: 2.0,
-                color: Colors.blue,
+                color: Theme.of(context).accentColor,
                 size: 38.0,
               ),
             ],

--- a/lib/ui/widgets/play_pause_button_widget.dart
+++ b/lib/ui/widgets/play_pause_button_widget.dart
@@ -67,7 +67,7 @@ class PlayPauseBusyButton extends StatelessWidget {
                 center: Icon(
                   icon,
                   size: 28.0,
-                  color: Colors.orange,
+                  color: Theme.of(context).buttonColor,
                 ),
               ),
               const SpinKitRing(

--- a/lib/ui/widgets/speed_selector_widget.dart
+++ b/lib/ui/widgets/speed_selector_widget.dart
@@ -47,7 +47,7 @@ class _SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
               Text(' ',
                   style: TextStyle(
                     fontSize: 12.0,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).buttonColor,
                   )),
               IconButton(
                 constraints: const BoxConstraints(
@@ -61,7 +61,7 @@ class _SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
                 icon: Icon(
                   Icons.speed,
                   size: 24.0,
-                  color: Theme.of(context).primaryColor,
+                  color: Theme.of(context).buttonColor,
                 ),
                 onPressed: () {
                   showDialog<void>(
@@ -102,7 +102,7 @@ class _SpeedSelectorWidgetState extends State<SpeedSelectorWidget> {
                   'x${snapshot.data.playbackSpeed}',
                   style: TextStyle(
                     fontSize: 12.0,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).buttonColor,
                   ),
                 ),
               ),

--- a/lib/ui/widgets/transport_controls.dart
+++ b/lib/ui/widgets/transport_controls.dart
@@ -224,7 +224,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).cancel_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of(context).buttonColor),
             ),
             onPressed: () {
               Navigator.pop(context);
@@ -233,7 +233,7 @@ class DownloadControl extends StatelessWidget {
           BasicDialogAction(
             title: Text(
               L.of(context).stop_download_button_label,
-              style: TextStyle(color: Colors.orange),
+              style: TextStyle(color: Theme.of(context).buttonColor),
             ),
             onPressed: () {
               _episodeBloc.deleteDownload(episode);


### PR DESCRIPTION
Made several changes for theme customization purposes, they have no visual effect on the plugin itself.

 - Replaced static colors with their theme counterparts
    - Colors.orange -> theme.primaryColor & theme.buttonColor,
    - Added a condition to prevent white on white color for Play/Pause icon,
    - Play/Pause button on Now Playing uses primaryColor for background & white for iconColor except when primaryColor is also white, which default the iconColor to scaffoldBackgroundColor
 - Added selectedItemColor and unselectedItemColor parameters to BottomNavigationBar,
 - Mini Player widgets
   - textTheme has changed to accentTextTheme,
   - divider now uses dividerColor from theme,
   - play button uses iconTheme.color instead of accentColor.
 
 
