### PR TITLE
Visual update to minimize button

### DIFF
--- a/lib/ui/podcast/now_playing.dart
+++ b/lib/ui/podcast/now_playing.dart
@@ -79,32 +79,38 @@ class _NowPlayingState extends State<NowPlaying> with WidgetsBindingObserver {
                       elevation: 0.0,
                       leading: IconButton(
                         tooltip: L.of(context).minimise_player_window_button_label,
-                        icon: Icon(Icons.keyboard_arrow_down),
+                        icon: Icon(Icons.keyboard_arrow_down, color: Theme.of(context).primaryColor),
                         onPressed: () => {
                           Navigator.pop(context),
                         },
                       ),
                     ),
                   ),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: <Widget>[
-                      snapshot.data == null
-                          ? Container()
-                          : Expanded(
-                              child: NowPlayingHeader(imageUrl: snapshot.data.imageUrl),
-                              flex: 6,
-                            ),
-                      Expanded(
-                        child: NowPlayingDetails(title: snapshot.data.title, description: snapshot.data.description),
-                        flex: 4,
-                      ),
-                      SizedBox(
-                        height: 160.0,
-                        child: NowPlayingTransport(duration: duration),
-                      ),
-                    ],
+                  Padding(
+                    padding: const EdgeInsets.only(top: 40.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: <Widget>[
+                        snapshot.data == null
+                            ? Container()
+                            : Expanded(
+                                child: NowPlayingHeader(
+                                    imageUrl: snapshot.data.imageUrl),
+                                flex: 9,
+                              ),
+                        Expanded(
+                          child: NowPlayingDetails(
+                              title: snapshot.data.title,
+                              description: snapshot.data.description),
+                          flex: 4,
+                        ),
+                        SizedBox(
+                          height: 160.0,
+                          child: NowPlayingTransport(duration: duration),
+                        ),
+                      ],
+                    ),
                   )
                 ],
               ),


### PR DESCRIPTION
Theme values are applied to minimize button on Now Playing page and it's layout is changed so that it's no longer under podcast image.
### Before
<img src="https://user-images.githubusercontent.com/4012752/106812359-9b29ff80-6680-11eb-8664-2b5b04df1eff.png" width="300"><img src="https://user-images.githubusercontent.com/4012752/106812367-9ebd8680-6680-11eb-8cef-b4148ff00edf.png" width="300">
### After
<img src="https://user-images.githubusercontent.com/4012752/106809768-21444700-667d-11eb-839a-d0ad904a01b9.png" width="300"><img src="https://user-images.githubusercontent.com/4012752/106809779-24d7ce00-667d-11eb-8629-15f34c8b503b.png" width="300">
