### PR TITLE
Customize androidNotificationColor of AudioService

### DIFF
--- a/lib/services/audio/mobile_audio_player_service.dart
+++ b/lib/services/audio/mobile_audio_player_service.dart
@@ -31,6 +31,7 @@ class MobileAudioPlayerService extends AudioPlayerService {
   final log = Logger('MobileAudioPlayerService');
   final Repository repository;
   final SettingsService settingsService;
+  final Color androidNotificationColor;
   double _playbackSpeed;
 
   Episode _episode;
@@ -49,6 +50,7 @@ class MobileAudioPlayerService extends AudioPlayerService {
   MobileAudioPlayerService({
     @required this.repository,
     @required this.settingsService,
+    this.androidNotificationColor,
   }) {
     _handleAudioServiceTransitions();
   }
@@ -293,7 +295,7 @@ class MobileAudioPlayerService extends AudioPlayerService {
       backgroundTaskEntrypoint: backgroundPlay,
       androidResumeOnClick: true,
       androidNotificationChannelName: 'Anytime Podcast Player',
-      androidNotificationColor: Colors.orange.value,
+      androidNotificationColor: androidNotificationColor?.value ?? Colors.orange.value,
       androidNotificationIcon: 'drawable/ic_stat_name',
       androidStopForegroundOnPause: true,
       fastForwardInterval: Duration(seconds: 30),


### PR DESCRIPTION
Added optional parameter, androidNotificationColor to MobileAudioPlayerService to be able to change notification color of audio service.