### PR TITLE
Add metadata hook.

### DIFF
--- a/lib/entities/episode.dart
+++ b/lib/entities/episode.dart
@@ -43,6 +43,7 @@ class Episode {
   // Index of the currently playing chapter it available. Transient.
   int chapterIndex;
   Chapter currentChapter;
+  Map<String, dynamic> metadata;
 
   Episode({
     @required this.guid,
@@ -69,6 +70,7 @@ class Episode {
     this.played = false,
     this.chaptersUrl,
     this.chapters,
+    this.metadata,
   });
 
   Map<String, dynamic> toMap() {
@@ -96,6 +98,7 @@ class Episode {
       'played': played ? 'true' : 'false',
       'chaptersUrl': chaptersUrl,
       'chapters': (chapters ?? <Chapter>[]).map((chapter) => chapter.toMap())?.toList(growable: false),
+      'metadata': metadata,
     };
   }
 
@@ -113,33 +116,33 @@ class Episode {
     }
 
     return Episode(
-      id: key,
-      guid: episode['guid'] as String,
-      pguid: episode['pguid'] as String,
-      downloadTaskId: episode['downloadTaskId'] as String,
-      filepath: episode['filepath'] as String,
-      filename: episode['filename'] as String,
-      downloadState: _determineState(episode['downloadState'] as int),
-      podcast: episode['podcast'] as String,
-      title: episode['title'] as String,
-      description: episode['description'] as String,
-      link: episode['link'] as String,
-      imageUrl: episode['imageUrl'] as String,
-      thumbImageUrl: episode['thumbImageUrl'] as String,
-      publicationDate: episode['publicationDate'] == 'null'
-          ? DateTime.now()
-          : DateTime.fromMillisecondsSinceEpoch(int.parse(episode['publicationDate'] as String)),
-      contentUrl: episode['contentUrl'] as String,
-      author: episode['author'] as String,
-      season: int.parse(episode['season'] as String ?? '0'),
-      episode: int.parse(episode['episode'] as String ?? '0'),
-      duration: int.parse(episode['duration'] as String ?? '0'),
-      position: int.parse(episode['position'] as String ?? '0'),
-      downloadPercentage: int.parse(episode['downloadPercentage'] as String ?? '0'),
-      played: episode['played'] == 'true' ? true : false,
-      chaptersUrl: episode['chaptersUrl'] as String,
-      chapters: chapters,
-    );
+        id: key,
+        guid: episode['guid'] as String,
+        pguid: episode['pguid'] as String,
+        downloadTaskId: episode['downloadTaskId'] as String,
+        filepath: episode['filepath'] as String,
+        filename: episode['filename'] as String,
+        downloadState: _determineState(episode['downloadState'] as int),
+        podcast: episode['podcast'] as String,
+        title: episode['title'] as String,
+        description: episode['description'] as String,
+        link: episode['link'] as String,
+        imageUrl: episode['imageUrl'] as String,
+        thumbImageUrl: episode['thumbImageUrl'] as String,
+        publicationDate: episode['publicationDate'] == 'null'
+            ? DateTime.now()
+            : DateTime.fromMillisecondsSinceEpoch(int.parse(episode['publicationDate'] as String)),
+        contentUrl: episode['contentUrl'] as String,
+        author: episode['author'] as String,
+        season: int.parse(episode['season'] as String ?? '0'),
+        episode: int.parse(episode['episode'] as String ?? '0'),
+        duration: int.parse(episode['duration'] as String ?? '0'),
+        position: int.parse(episode['position'] as String ?? '0'),
+        downloadPercentage: int.parse(episode['downloadPercentage'] as String ?? '0'),
+        played: episode['played'] == 'true' ? true : false,
+        chaptersUrl: episode['chaptersUrl'] as String,
+        chapters: chapters,
+        metadata: episode['metadata'] as Map<String, dynamic>);
   }
 
   static DownloadState _determineState(int index) {

--- a/lib/entities/podcast.dart
+++ b/lib/entities/podcast.dart
@@ -21,6 +21,7 @@ class Podcast {
   final List<Funding> funding;
   DateTime subscribedDate;
   List<Episode> episodes;
+  Map<String, dynamic> metadata;
 
   Podcast({
     @required this.guid,
@@ -35,6 +36,7 @@ class Podcast {
     this.subscribedDate,
     this.funding,
     this.episodes,
+    this.metadata,
   }) {
     episodes ??= [];
   }
@@ -61,6 +63,7 @@ class Podcast {
       'thumbImageUrl': thumbImageUrl ?? '',
       'subscribedDate': subscribedDate?.millisecondsSinceEpoch.toString() ?? '',
       'funding': (funding ?? <Funding>[]).map((funding) => funding.toMap())?.toList(growable: false),
+      'metadata': metadata,
     };
   }
 
@@ -93,6 +96,7 @@ class Podcast {
       thumbImageUrl: podcast['thumbImageUrl'] as String,
       funding: funding,
       subscribedDate: sd,
+      metadata: podcast['metadata'] as Map<String, dynamic>,
     );
   }
 
@@ -100,8 +104,7 @@ class Podcast {
 
   @override
   bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Podcast && runtimeType == other.runtimeType && guid == other.guid && url == other.url;
+      identical(this, other) || other is Podcast && runtimeType == other.runtimeType && guid == other.guid && url == other.url;
 
   @override
   int get hashCode => guid.hashCode ^ url.hashCode;


### PR DESCRIPTION
Since some tags that returned from the Podcast Index API do not exist in the rss feed, we need to call this API in order to load it, specifically the value tag.
When these tags are fully adopted they will be part of the rss feed but until then I suggest here to add this hook so external caller have a way to load their own metadata. We will call podcast index API and add the value tags as metadata.
This can be used later by payment app to pay for the podcast streaming time.
The other option is to call the API internally in the search result and add another parsing method (from json) so I preferred this small hook and keep the library clean.