### PR TITLE
Apply theme changes to mini player widget

### DIFF
--- a/lib/ui/podcast/chapter_selector.dart
+++ b/lib/ui/podcast/chapter_selector.dart
@@ -101,6 +101,15 @@ class _ChapterSelectorState extends State<ChapterSelector> {
             itemBuilder: (context, index) {
               final chapter = chapters[index];
               final chapterSelected = widget?.chapter == chapter;
+              final textStyle = chapterSelected
+                  ? Theme.of(context).accentTextTheme.bodyText1.copyWith(
+                        fontSize: 14,
+                        fontWeight: FontWeight.normal,
+                      )
+                  : Theme.of(context).textTheme.bodyText1.copyWith(
+                        fontSize: 14,
+                        fontWeight: FontWeight.normal,
+                      );
 
               return Padding(
                 padding: const EdgeInsets.fromLTRB(4.0, 0.0, 4.0, 0.0),
@@ -114,10 +123,7 @@ class _ChapterSelectorState extends State<ChapterSelector> {
                     padding: const EdgeInsets.all(4.0),
                     child: Text(
                       '${index + 1}.',
-                      style: Theme.of(context).textTheme.bodyText1.copyWith(
-                            fontSize: 14,
-                            fontWeight: FontWeight.normal,
-                          ),
+                      style: textStyle,
                     ),
                   ),
                   title: Text(
@@ -125,11 +131,11 @@ class _ChapterSelectorState extends State<ChapterSelector> {
                     overflow: TextOverflow.ellipsis,
                     softWrap: false,
                     maxLines: 3,
-                    style: Theme.of(context).textTheme.bodyText1.copyWith(fontSize: 14, fontWeight: FontWeight.normal),
+                    style: textStyle,
                   ),
                   trailing: Text(
                     _formatStartTime(chapters[index].startTime),
-                    style: Theme.of(context).textTheme.bodyText1.copyWith(fontSize: 14, fontWeight: FontWeight.normal),
+                    style: textStyle,
                   ),
                 ),
               );

--- a/lib/ui/widgets/mini_player.dart
+++ b/lib/ui/widgets/mini_player.dart
@@ -65,7 +65,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final textTheme = Theme.of(context).accentTextTheme;
     final audioBloc = Provider.of<AudioBloc>(context, listen: false);
 
     return Dismissible(
@@ -163,7 +163,7 @@ class _MiniPlayerBuilderState extends State<_MiniPlayerBuilder> with SingleTicke
                               child: AnimatedIcon(
                                 size: 48.0,
                                 icon: AnimatedIcons.play_pause,
-                                color: Theme.of(context).buttonColor,
+                                color: Theme.of(context).iconTheme.color,
                                 progress: _playPauseController,
                               ),
                             );


### PR DESCRIPTION
This PR contains mini player widgets that were overlooked on https://github.com/amugofjava/anytime_podcast_player/pull/14

 - Mini player uses accentTextTheme and play pause uses iconTheme.color,
 
 _These changes are for customization purposes only and they have no effect on plugins own theme._