### PR TITLE
Add Show Funding Menu settings to show/hide FundingMenu on PodcastDetails

### DIFF
--- a/lib/bloc/settings/settings_bloc.dart
+++ b/lib/bloc/settings/settings_bloc.dart
@@ -24,6 +24,7 @@ class SettingsBloc extends Bloc {
   final BehaviorSubject<String> _searchProvider = BehaviorSubject<String>();
   final BehaviorSubject<bool> _externalLinkConsent = BehaviorSubject<bool>();
   final BehaviorSubject<bool> _autoOpenNowPlaying = BehaviorSubject<bool>();
+  final BehaviorSubject<bool> _showFunding = BehaviorSubject<bool>();
 
   SettingsBloc(this._settingsService) {
     _init();
@@ -39,6 +40,7 @@ class SettingsBloc extends Bloc {
     var themeName = themeDarkMode ? 'dark' : 'light';
     var searchProvider = _settingsService.searchProvider;
     var externalLinkConsent = _settingsService.externalLinkConsent;
+    var showFunding = _settingsService.showFunding;
 
     // Add our available search providers.
     var providers = <SearchProvider>[SearchProvider(key: 'itunes', name: 'iTunes')];
@@ -56,6 +58,7 @@ class SettingsBloc extends Bloc {
       searchProviders: providers,
       externalLinkConsent: externalLinkConsent,
       autoOpenNowPlaying: autoOpenNowPlaying,
+      showFunding: showFunding,
     );
 
     _settings.add(s);
@@ -72,6 +75,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: externalLinkConsent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -91,6 +95,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: externalLinkConsent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -110,6 +115,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: externalLinkConsent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -127,6 +133,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: externalLinkConsent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -138,18 +145,41 @@ class SettingsBloc extends Bloc {
       autoOpenNowPlaying = autoOpen;
 
       s = AppSettings(
-          theme: themeName,
-          markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
-          storeDownloadsSDCard: storeDownloadsSDCard,
-          playbackSpeed: playbackSpeed,
-          searchProvider: searchProvider,
-          searchProviders: providers,
-          externalLinkConsent: externalLinkConsent,
-          autoOpenNowPlaying: autoOpen);
+        theme: themeName,
+        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+        storeDownloadsSDCard: storeDownloadsSDCard,
+        playbackSpeed: playbackSpeed,
+        searchProvider: searchProvider,
+        searchProviders: providers,
+        externalLinkConsent: externalLinkConsent,
+        autoOpenNowPlaying: autoOpen,
+        showFunding: showFunding,
+      );
 
       _settings.add(s);
 
       _settingsService.autoOpenNowPlaying = autoOpen;
+    });
+
+    _showFunding.listen((show) {
+      s = AppSettings(
+        theme: themeName,
+        markDeletedEpisodesAsPlayed: markDeletedEpisodesAsPlayed,
+        storeDownloadsSDCard: storeDownloadsSDCard,
+        playbackSpeed: playbackSpeed,
+        searchProvider: searchProvider,
+        searchProviders: providers,
+        externalLinkConsent: externalLinkConsent,
+        autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: show,
+      );
+
+      _settings.add(s);
+
+      // If the setting has not changed, don't bother updating it
+      if (show != showFunding) {
+        _settingsService.showFunding = show;
+      }
     });
 
     _searchProvider.listen((search) {
@@ -162,6 +192,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: externalLinkConsent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -179,6 +210,7 @@ class SettingsBloc extends Bloc {
         searchProviders: providers,
         externalLinkConsent: consent,
         autoOpenNowPlaying: autoOpenNowPlaying,
+        showFunding: showFunding,
       );
 
       _settings.add(s);
@@ -205,6 +237,8 @@ class SettingsBloc extends Bloc {
   void Function(String) get setSearchProvider => _searchProvider.add;
 
   void Function(bool) get setExternalLinkConsent => _externalLinkConsent.add;
+
+  void Function(bool) get setShowFunding => _showFunding.add;
 
   @override
   void dispose() {

--- a/lib/entities/app_settings.dart
+++ b/lib/entities/app_settings.dart
@@ -14,6 +14,7 @@ class AppSettings {
   final List<SearchProvider> searchProviders;
   final bool externalLinkConsent;
   final bool autoOpenNowPlaying;
+  final bool showFunding;
 
   AppSettings({
     @required this.theme,
@@ -24,6 +25,7 @@ class AppSettings {
     @required this.searchProviders,
     @required this.externalLinkConsent,
     @required this.autoOpenNowPlaying,
+    @required this.showFunding,
   });
 
   AppSettings.sensibleDefaults()
@@ -34,5 +36,6 @@ class AppSettings {
         searchProvider = 'itunes',
         searchProviders = <SearchProvider>[],
         externalLinkConsent = false,
-        autoOpenNowPlaying = false;
+        autoOpenNowPlaying = false,
+        showFunding = true;
 }

--- a/lib/services/settings/mobile_settings_service.dart
+++ b/lib/services/settings/mobile_settings_service.dart
@@ -95,5 +95,15 @@ class MobileSettingsService extends SettingsService {
   }
 
   @override
+  set showFunding(bool show) {
+    _sharedPreferences.setBool('showFunding', show);
+  }
+
+  @override
+  bool get showFunding {
+    return _sharedPreferences.getBool('showFunding') ?? true;
+  }
+
+  @override
   AppSettings settings;
 }

--- a/lib/services/settings/settings_service.dart
+++ b/lib/services/settings/settings_service.dart
@@ -32,4 +32,8 @@ abstract class SettingsService {
   set autoOpenNowPlaying(bool autoOpenNowPlaying);
 
   bool get autoOpenNowPlaying;
+
+  set showFunding(bool show);
+
+  bool get showFunding;
 }

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:anytime/bloc/podcast/podcast_bloc.dart';
+import 'package:anytime/bloc/settings/settings_bloc.dart';
 import 'package:anytime/core/chrome.dart';
+import 'package:anytime/entities/app_settings.dart';
 import 'package:anytime/entities/episode.dart';
 import 'package:anytime/entities/feed.dart';
 import 'package:anytime/entities/podcast.dart';
@@ -288,40 +290,51 @@ class PodcastTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    final _settingsBloc = Provider.of<SettingsBloc>(context);
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(8.0, 16.0, 8.0, 0.0),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Text(podcast.title ?? '', style: textTheme.headline6),
-          ),
-          Padding(
-            padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
-            child: Text(podcast.copyright ?? '', style: textTheme.caption),
-          ),
-          Html(
-            data: podcast.description ?? '',
-            style: {'html': Style(fontWeight: textTheme.bodyText1.fontWeight)},
-            onLinkTap: (url) => canLaunch(url).then((value) => launch(url)),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(left: 8.0, right: 8.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: <Widget>[
-                SubscriptionButton(podcast),
-                PodcastContextMenu(podcast),
-                FundingMenu(podcast.funding),
-              ],
+    return StreamBuilder<AppSettings>(
+        stream: _settingsBloc.settings,
+        builder: (context, settingsSnapshot)
+    {
+      if (!settingsSnapshot.hasData) {
+        return SizedBox();
+      }
+      final settings = settingsSnapshot.data;
+
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(8.0, 16.0, 8.0, 0.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Text(podcast.title ?? '', style: textTheme.headline6),
             ),
-          )
-        ],
-      ),
-    );
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
+              child: Text(podcast.copyright ?? '', style: textTheme.caption),
+            ),
+            Html(
+              data: podcast.description ?? '',
+              style: {'html': Style(fontWeight: textTheme.bodyText1.fontWeight)},
+              onLinkTap: (url) => canLaunch(url).then((value) => launch(url)),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: <Widget>[
+                  SubscriptionButton(podcast),
+                  PodcastContextMenu(podcast),
+                  settings.showFunding ? FundingMenu(podcast.funding) : Container(),
+                ],
+              ),
+            )
+          ],
+        ),
+      );
+    });
   }
 }
 


### PR DESCRIPTION
Since we have our own payment system integrated into the plugin via hooks, this raised the need to hide `FundingMenu` on `PodcastDetails` page. We believe the least intrusive way to go with this change was to add a `showFunding` flag to `AppSettings`.

This PR introduces `showFunding` settings flag that allows developers to hide `FundingMenu` on `PodcastDetails` page.
This setting is `true` by default and won't be configurable through `Settings` page.