### PR TITLE
Load chapters via API.

### DIFF
--- a/lib/services/podcast/mobile_podcast_service.dart
+++ b/lib/services/podcast/mobile_podcast_service.dart
@@ -210,7 +210,7 @@ class MobilePodcastService extends PodcastService {
 
   @override
   Future<List<Chapter>> loadChaptersByUrl({@required String url}) async {
-    var c = await psapi.Podcast.loadChaptersByUrl(url: url);
+    var c = await api.loadChapters(url);
     var chapters = <Chapter>[];
 
     if (c != null) {


### PR DESCRIPTION
This is a small fix that goes through the API layer to load chapters instead of directly invoking the implementation.