### PR TITLE
Add foregroundColor to show notes page

### DIFF
--- a/lib/ui/widgets/show_notes.dart
+++ b/lib/ui/widgets/show_notes.dart
@@ -30,6 +30,7 @@ class ShowNotes extends StatelessWidget {
             brightness: Theme.of(context).brightness,
             title: Text(episode.podcast),
             backgroundColor: Theme.of(context).appBarTheme.color,
+            foregroundColor: Theme.of(context).appBarTheme.foregroundColor,
             floating: false,
             pinned: true,
             snap: false,


### PR DESCRIPTION
This is one of the occasions where we need to specify which color to use to leading icon.
