### PR TITLE
Refresh the podcast on Podcast Details page creation

### DIFF
--- a/lib/bloc/podcast/podcast_bloc.dart
+++ b/lib/bloc/podcast/podcast_bloc.dart
@@ -32,7 +32,7 @@ class PodcastBloc extends Bloc {
   final PodcastService podcastService;
   final AudioPlayerService audioPlayerService;
   final DownloadService downloadService;
-  final PublishSubject<Feed> _podcastFeed = PublishSubject<Feed>(sync: true);
+  final BehaviorSubject<Feed> _podcastFeed = BehaviorSubject<Feed>(sync: true);
 
   /// Add to sink to start an Episode download
   final PublishSubject<Episode> _downloadEpisode = PublishSubject<Episode>();
@@ -104,6 +104,13 @@ class PodcastBloc extends Bloc {
           podcast: feed.podcast,
           refresh: feed.refresh,
         );
+
+        final lastFeed = _podcastFeed.value;
+        if (lastFeed != null && feed.podcast.id != lastFeed.podcast.id) {
+          log.fine('Not emitting episodes and podcast for id:${feed.podcast.id}'
+              ' because last requested podcast is id:${lastFeed.podcast.id}');
+          return;
+        }
 
         _episodes = _podcast?.episodes;
         _episodesStream.add(_episodes);

--- a/lib/bloc/podcast/podcast_bloc.dart
+++ b/lib/bloc/podcast/podcast_bloc.dart
@@ -117,6 +117,19 @@ class PodcastBloc extends Bloc {
 
         _podcastStream.sink.add(BlocPopulatedState<Podcast>(_podcast));
       } catch (e) {
+        final lastFeed = _podcastFeed.value;
+        if (lastFeed != null && feed.podcast.id != lastFeed.podcast.id) {
+          log.fine('Not emitting the error for id:${feed.podcast.id} because'
+              ' last requested podcast is id:${lastFeed.podcast.id}', e);
+          return;
+        }
+
+        if (feed.silently) {
+          log.fine('Not emitting the error for id:${feed.podcast.id}'
+              ' because feed requested a silently update', e);
+          return;
+        }
+
         // For now we'll assume a network error as this is the most likely.
         _podcastStream.sink.add(BlocErrorState<Podcast>());
         log.fine('Error loading podcast', e);

--- a/lib/entities/feed.dart
+++ b/lib/entities/feed.dart
@@ -22,10 +22,14 @@ class Feed {
   /// If true the podcast is loaded regardless of if it's currently cached.
   bool refresh;
 
+  /// If true any error can be ignored.
+  bool silently;
+
   Feed({
     @required this.podcast,
     this.imageUrl,
     this.thumbImageUrl,
     this.refresh = false,
+    this.silently = false,
   });
 }

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -95,7 +95,11 @@ class _PodcastDetailsState extends State<PodcastDetails> {
       }
     });
 
-    _handleRefresh();
+    widget._podcastBloc.load(Feed(
+      podcast: widget.podcast,
+      refresh: true,
+      silently: true,
+    ));
   }
 
   @override

--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -94,6 +94,8 @@ class _PodcastDetailsState extends State<PodcastDetails> {
         });
       }
     });
+
+    _handleRefresh();
   }
 
   @override


### PR DESCRIPTION
Add a minor convenience to the user, whenever the user opens the podcast detail it silently updates the list of episodes.

Based on this suggestion: https://github.com/breez/breezmobile/issues/456

# How it looks like

https://user-images.githubusercontent.com/1225438/123450993-ab049a80-d5b3-11eb-8930-d92b04815276.mp4

