### PR TITLE
Take most up to date duration from playback event.

### DIFF
--- a/lib/services/audio/default_audio_player_service.dart
+++ b/lib/services/audio/default_audio_player_service.dart
@@ -679,6 +679,12 @@ class _DefaultAudioPlayerHandler extends BaseAudioHandler with SeekHandler {
   }
 
   PlaybackState _transformEvent(PlaybackEvent event) {
+    int currentDuration = _currentItem?.duration?.inSeconds ?? 0;
+    int updatedDuration = event?.duration?.inSeconds ?? 0;
+    if (currentDuration == 0 && currentDuration != updatedDuration) {
+      _currentItem = _currentItem.copyWith.call(duration: Duration(seconds: updatedDuration));
+      super.mediaItem.add(_currentItem);
+    }
     return PlaybackState(
       controls: [
         rewindControl,


### PR DESCRIPTION
For some podcasts the <itunes:duration> tag is not presented in the RSS feed.
This PR takes the duration from the underline player when this data is available.