### PR TITLE
Fix required flutter version to 2.2.3.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.1.0+61
 
 environment:
   sdk: ">=2.10.0 <3.0.0"
+  flutter: 2.2.3
 
 dependencies:
   auto_size_text: ^2.1.0


### PR DESCRIPTION
Hi 👋

I had to try many Flutter SDK versions to find which is required on AnytimePodcast.
So, it could be useful to set it explicitly in the project setup.

Cheers