### PR TITLE
Display podcast even if missing title, description, or copyright tags

### DIFF
--- a/lib/services/podcast/mobile_podcast_service.dart
+++ b/lib/services/podcast/mobile_podcast_service.dart
@@ -382,9 +382,12 @@ class MobilePodcastService extends PodcastService {
   /// Remove HTML padding from the content. The padding may look fine within
   /// the context of a browser, but can look out of place on a mobile screen.
   String _format(String input) {
-    input = input.replaceAll('\n', '').trim() ?? '';
-
-    return input.replaceAll(descriptionRegExp2, '')..replaceAll(descriptionRegExp1, '</p>');
+    return input
+            ?.replaceAll('\n', '')
+            ?.trim()
+            ?.replaceAll(descriptionRegExp2, '')
+            ?.replaceAll(descriptionRegExp1, '</p>') ??
+        '';
   }
 
   Future<psearch.Chapters> _loadChaptersByUrl(String url) {


### PR DESCRIPTION
I ran into an issue loading this RSS feed manually: http://adc.equalarea.com/feed/ - because this feed is missing a `<copyright>` tag, it cannot be loaded. This PR fixes this issue.

(Note that even with this fix, items from this feed cannot be successfully downloaded, because of an issue with two `<enclosure>` tags in a single item. That's an edge case that [isn't supported according to Apple's spec](https://podcasters.apple.com/support/823-podcast-requirements), but it should be a simple fix - let me know if you'd accept a PR to podcast_search to fix that issue, or if that's too weird a scenario to bother with the extra complexity.)