### PR TITLE
add animation in podcast description button

### DIFF
--- a/lib/ui/podcast/podcast_details.dart
+++ b/lib/ui/podcast/podcast_details.dart
@@ -485,13 +485,14 @@ class PodcastDescription extends StatelessWidget {
         stream: isDescriptionExpandedStream.stream,
         initialData: false,
         builder: (context, snapshot) {
+          final expanded = snapshot.data;
           return AnimatedSize(
                   duration: Duration(milliseconds : 150),
                   curve: Curves.fastOutSlowIn,
-                  // size: snapshot.data ? null : maxHeight- padding,
+                  alignment: Alignment.topCenter,
                   child: Container( 
-                  constraints: snapshot.data ? BoxConstraints() :  BoxConstraints.loose(Size(double.infinity, maxHeight - padding)),
-                    child: ShaderMask(
+                  constraints: expanded ? BoxConstraints() :  BoxConstraints.loose(Size(double.infinity, maxHeight - padding)),
+                    child: expanded ? content :ShaderMask(
                       shaderCallback: LinearGradient(
                         colors: [Colors.white, Colors.white.withAlpha(0)],
                         begin: Alignment.topCenter,


### PR DESCRIPTION
Hopefully close #47 
I have used StreamController to trigger animation instead of SetState() because the parent widget was rebuilding the whole description Text widget instead of animating. 
I am open to suggestions if there is a better way to achieve this. Though I think this one isn't bad either.