### PR TITLE
OPML Export - throws error on iOS

### DIFF
--- a/lib/ui/library/opml_export.dart
+++ b/lib/ui/library/opml_export.dart
@@ -31,7 +31,9 @@ class _OPMLExportState extends State<OPMLExport> {
           stream: bloc.opmlState,
           builder: (context, snapshot) {
             if (snapshot.data is OPMLCompletedState) {
-              Navigator.pop(context);
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                Navigator.pop(context);
+              });
             }
 
             return Row(


### PR DESCRIPTION
Fixes #91

Error comes from context manipulation done
synchronously in `build` method.