### PR TITLE
Accept all HTTP connections on iOS.

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,8 +30,6 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
-		<key>NSAllowsArbitraryLoadsForMedia</key>
-		<true/>
 	</dict>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>File access is required to facilitate locating and importing OPML files</string>


### PR DESCRIPTION
Closes https://github.com/amugofjava/anytime_podcast_player/issues/62

This is simple fix allowing all HTTP (non secured) connections on iOS. 

There is[ another approach](https://github.com/amugofjava/anytime_podcast_player/pull/69) disable HTTP connections, and attempting to replace all `http://` by `https://`