### PR TITLE
fix auto download refresh

### DIFF
--- a/lib/bloc/podcast/episode_bloc.dart
+++ b/lib/bloc/podcast/episode_bloc.dart
@@ -49,8 +49,10 @@ class EpisodeBloc extends Bloc {
   }
 
   void _init() {
-    _downloadsOutput = _downloadsInput.switchMap<BlocState<List<Episode>>>((bool silent) => _loadDownloads(silent));
-    _episodesOutput = _episodesInput.switchMap<BlocState<List<Episode>>>((bool silent) => _loadEpisodes(silent));
+    _downloadsOutput = _downloadsInput.switchMap<BlocState<List<Episode>>>(
+        (bool silent) => _loadDownloads(silent));
+    _episodesOutput = _episodesInput.switchMap<BlocState<List<Episode>>>(
+        (bool silent) => _loadEpisodes(silent));
 
     _handleDeleteDownloads();
     _handleMarkAsPlayed();
@@ -84,9 +86,10 @@ class EpisodeBloc extends Bloc {
     podcastService.episodeListener.listen((state) {
       // Do we have this episode?
       if (_episodes != null) {
-        var episode = _episodes.indexWhere((e) => e.pguid == state.episode.pguid && e.guid == state.episode.guid);
-
-        if (episode != -1) {
+        var episode = _episodes.indexWhere((e) =>
+            e.pguid == state.episode.pguid && e.guid == state.episode.guid);
+        bool downloadCompleted = state.episode.downloaded;
+        if (episode == -1 && downloadCompleted) {
           fetchDownloads(true);
         }
       }

--- a/lib/bloc/podcast/episode_bloc.dart
+++ b/lib/bloc/podcast/episode_bloc.dart
@@ -49,10 +49,8 @@ class EpisodeBloc extends Bloc {
   }
 
   void _init() {
-    _downloadsOutput = _downloadsInput.switchMap<BlocState<List<Episode>>>(
-        (bool silent) => _loadDownloads(silent));
-    _episodesOutput = _episodesInput.switchMap<BlocState<List<Episode>>>(
-        (bool silent) => _loadEpisodes(silent));
+    _downloadsOutput = _downloadsInput.switchMap<BlocState<List<Episode>>>((bool silent) => _loadDownloads(silent));
+    _episodesOutput = _episodesInput.switchMap<BlocState<List<Episode>>>((bool silent) => _loadEpisodes(silent));
 
     _handleDeleteDownloads();
     _handleMarkAsPlayed();
@@ -86,8 +84,7 @@ class EpisodeBloc extends Bloc {
     podcastService.episodeListener.listen((state) {
       // Do we have this episode?
       if (_episodes != null) {
-        var episode = _episodes.indexWhere((e) =>
-            e.pguid == state.episode.pguid && e.guid == state.episode.guid);
+        var episode = _episodes.indexWhere((e) => e.pguid == state.episode.pguid && e.guid == state.episode.guid);
         bool downloadCompleted = state.episode.downloaded;
         if (episode == -1 && downloadCompleted) {
           fetchDownloads(true);


### PR DESCRIPTION
Fixes #86 

Seems like episodeIndex check in listener was not correct. If episode not found in current downloads list then it should be -1 and Refetch download list.
I changed the condition but not sure if it was necessary for other functionality in the application.
Now it checks if the episode is not present and download is completed only then Refetch download list.