### PR TITLE
fix closing "auto update episodes" dialog on macos

### DIFF
--- a/lib/ui/settings/episode_refresh.dart
+++ b/lib/ui/settings/episode_refresh.dart
@@ -5,6 +5,7 @@
 import 'package:anytime/bloc/settings/settings_bloc.dart';
 import 'package:anytime/entities/app_settings.dart';
 import 'package:anytime/l10n/L.dart';
+import 'package:anytime/ui/widgets/action_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dialogs/flutter_dialogs.dart';
 import 'package:provider/provider.dart';
@@ -146,6 +147,18 @@ class _EpisodeRefreshWidgetState extends State<EpisodeRefreshWidget> {
                                     });
                                   },
                                 ),
+                                SimpleDialogOption(
+                                  padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 24.0),
+                                  child: Align(
+                                    alignment: Alignment.centerRight,
+                                    child: TextButton(
+                                      child: ActionText(L.of(context)!.close_button_label),
+                                      onPressed: () {
+                                        Navigator.pop(context);
+                                      },
+                                    ),
+                                  ),
+                                )
                               ]);
                             },
                           ));


### PR DESCRIPTION
just a suggestion to fix #151 

`flutter_dialogs` seems to be dead so I did not bother to do a PR there to expose the `barrierDismissible` param.

Or maybe there's another way to dispose the dialog on macos that I do not know of.. :)